### PR TITLE
Add MCP service console app

### DIFF
--- a/src/Ews.Code.Analyzer/Ews.Analyzer.McpService/Ews.Analyzer.McpService.csproj
+++ b/src/Ews.Code.Analyzer/Ews.Analyzer.McpService/Ews.Analyzer.McpService.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Ews.Analyzer\Ews.Analyzer.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Ews.Code.Analyzer/Ews.Analyzer.McpService/Program.cs
+++ b/src/Ews.Code.Analyzer/Ews.Analyzer.McpService/Program.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Ews.Analyzer;
+
+class Program
+{
+    static async Task Main()
+    {
+        string? line;
+        while ((line = Console.ReadLine()) != null)
+        {
+            using var doc = JsonDocument.Parse(line);
+            var root = doc.RootElement;
+            var idElement = root.GetProperty("id");
+            var method = root.GetProperty("method").GetString();
+            object result;
+
+            switch (method)
+            {
+                case "initialize":
+                    result = new { capabilities = new { } };
+                    break;
+                case "tools/list":
+                    result = new
+                    {
+                        tools = new object[]
+                        {
+                            new
+                            {
+                                name = "analyzeCode",
+                                description = "Run EWS analyzer on provided C# source code",
+                                inputSchema = new
+                                {
+                                    type = "object",
+                                    properties = new
+                                    {
+                                        code = new
+                                        {
+                                            type = "string",
+                                            description = "C# source code to analyze"
+                                        }
+                                    },
+                                    required = new[] { "code" }
+                                }
+                            },
+                            new
+                            {
+                                name = "getRoadmap",
+                                description = "Return migration roadmap for an EWS operation",
+                                inputSchema = new
+                                {
+                                    type = "object",
+                                    properties = new
+                                    {
+                                        operation = new
+                                        {
+                                            type = "string",
+                                            description = "EWS operation name"
+                                        }
+                                    },
+                                    required = new[] { "operation" }
+                                }
+                            }
+                        }
+                    };
+                    break;
+                case "tools/call":
+                    result = await HandleToolCallAsync(root.GetProperty("params"));
+                    break;
+                case "shutdown":
+                    result = null;
+                    break;
+                default:
+                    result = new
+                    {
+                        error = $"Unknown method {method}"
+                    };
+                    break;
+            }
+
+            object id = idElement.ValueKind switch
+            {
+                JsonValueKind.Number => idElement.GetInt32(),
+                JsonValueKind.String => idElement.GetString()!,
+                _ => null!
+            };
+
+            var response = new
+            {
+                jsonrpc = "2.0",
+                id,
+                result
+            };
+
+            Console.WriteLine(JsonSerializer.Serialize(response));
+
+            if (method == "shutdown")
+            {
+                break;
+            }
+        }
+    }
+
+    private static async Task<object> HandleToolCallAsync(JsonElement element)
+    {
+        var name = element.GetProperty("name").GetString();
+        var args = element.GetProperty("arguments");
+
+        switch (name)
+        {
+            case "analyzeCode":
+                var code = args.GetProperty("code").GetString() ?? string.Empty;
+                var diagnostics = await AnalyzeAsync(code);
+                return new
+                {
+                    content = new object[]
+                    {
+                        new
+                        {
+                            type = "text",
+                            text = JsonSerializer.Serialize(diagnostics)
+                        }
+                    }
+                };
+            case "getRoadmap":
+                var operation = args.GetProperty("operation").GetString() ?? string.Empty;
+                var roadmap = GetRoadmap(operation);
+                return new
+                {
+                    content = new object[]
+                    {
+                        new
+                        {
+                            type = "text",
+                            text = JsonSerializer.Serialize(roadmap)
+                        }
+                    }
+                };
+            default:
+                return new
+                {
+                    content = new object[]
+                    {
+                        new
+                        {
+                            type = "text",
+                            text = $"Unknown tool {name}"
+                        }
+                    }
+                };
+        }
+    }
+
+    private static async Task<IEnumerable<object>> AnalyzeAsync(string code)
+    {
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create(
+            "Analysis",
+            new[] { tree },
+            new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var analyzer = new EwsAnalyzer();
+        var compilationWithAnalyzers = new CompilationWithAnalyzers(
+            compilation,
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var diagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        var list = new List<object>();
+        foreach (var d in diagnostics)
+        {
+            list.Add(new
+            {
+                id = d.Id,
+                message = d.GetMessage(),
+                severity = d.Severity.ToString(),
+                location = d.Location.GetLineSpan().StartLinePosition.Line + 1
+            });
+        }
+        return list;
+    }
+
+    private static EwsMigrationRoadmap GetRoadmap(string operation)
+    {
+        var navigator = new EwsMigrationNavigator();
+        return navigator.GetMapByEwsOperation(operation);
+    }
+}

--- a/src/Ews.Code.Analyzer/Ews.Analyzer.sln
+++ b/src/Ews.Code.Analyzer/Ews.Analyzer.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ews.Analyzer.Vsix", "Ews.An
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ews.Test.App", "Ews.Test.App\Ews.Test.App.csproj", "{11A106EE-20E6-4B21-9084-CE5A05337CA9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ews.Analyzer.McpService", "Ews.Analyzer.McpService\Ews.Analyzer.McpService.csproj", "{FE02976E-D6B3-47F0-A628-589669B75877}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{060FB506-52DB-46F3-AE20-DA5D713241FD}"
 EndProject
 Global
@@ -47,6 +49,10 @@ Global
 		{11A106EE-20E6-4B21-9084-CE5A05337CA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{11A106EE-20E6-4B21-9084-CE5A05337CA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{11A106EE-20E6-4B21-9084-CE5A05337CA9}.Release|Any CPU.Build.0 = Release|Any CPU
+                {FE02976E-D6B3-47F0-A628-589669B75877}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {FE02976E-D6B3-47F0-A628-589669B75877}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {FE02976E-D6B3-47F0-A628-589669B75877}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {FE02976E-D6B3-47F0-A628-589669B75877}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add Ews.Analyzer.McpService console app hosting MCP-compliant JSON-RPC server
- register analyzeCode and getRoadmap tools
- wire tools/call to run EwsAnalyzer or return EwsMigrationRoadmap

## Testing
- `dotnet build src/Ews.Code.Analyzer/Ews.Analyzer.McpService/Ews.Analyzer.McpService.csproj` (fails: command not found)
- `dotnet test src/Ews.Code.Analyzer/Ews.Analyzer.sln` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68acbb4abf8c8330b0c5f00368e989e6